### PR TITLE
Updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,55 +16,56 @@ To find an upcoming session, visit [this etherpad][discussion].
 
 Mentoring groups support instructors by matching them with a personal mentor. Mentors will guide small groups (~4-5) of mentees, guiding them through specific goals including preparing to teach a workshop, maintaining lessons, building local communities, and organizing workshops.
 
-See [this page](https://github.com/carpentries/mentoring/blob/master/mentoring-groups/program-outline.md) for a full outline of the program.
+See [this page](https://docs.carpentries.org/topic_folders/instructor_development/mentoring_groups.html) for a full outline of the program.
 
 ### Committee Meetings
 
-The Instructor Development Committee itself meets on the third Monday of every month to 
-evaluate current activities, and propose
-new activities.  Minutes of past meetings are available [here](minutes).  All community
-members are welcome to attend these meetings.  Similarly, we welcome
-anyone who is interested in joining up and helping out!
+The Instructor Development Committee meets on the third Monday of every month to evaluate current activities, and propose
+new activities.  Minutes of past meetings are available [here](minutes).  All community members are welcome to attend these meetings.  Similarly, we welcome anyone who is interested in joining up and helping out!
 
 To attend our next meeting, visit [this etherpad][meetings].
 
 ## Join Us!
 
-Any Software, Library or Data Carpentry community member is welcome to participate in
-Instructor Development Committee activities and/or join the committee itself!  Some different
-options for getting involved are given below.
-
-I would like to:
+Any Carpentries community member is welcome to participate in Instructor Development Committee activities and/or join the committee! Some options for getting involved are provided below.
 
 - join a small group to receive mentoring from experienced instructors OR
 - mentor new instructors
-	- Join a mentoring group by contacting [Kari L. Jordan](mailto:kariljordan@carpentries.org)
-- discuss workshop experiences with other instructors OR
-- ask questions of other instructors as I prepare to teach
+	- Join a mentoring group by contacting [Marco Chiapello](mailto:chiapello.m@gmail.com).
+	- For a complete summary of different mentoring roles, see [this page](https://docs.carpentries.org/topic_folders/instructor_development/mentoring_groups.html#mentoring-groups-roles).
+- discuss workshop experiences with other instructors OR ask questions of other instructors as you prepare to teach
 	- Attend an instructor discussion session by signing up on [this etherpad][discussion].
+	- Sign up to host a Themed Discussion Session or #CarpentriesConversation by completing [this form](https://forms.gle/W39ckwAT8njKyUA87).
+	- Get more information about Community Discussions by contacting [Martin Dreyer](mailto:amfdrey@gmail.com).
 - help lead discussion sessions among instructors
 	- Join the [discussion host mailing list][host-mailing-list] and sign up to host, co-host, or observe
 	a discussion on [this etherpad][discussion]
-- support current mentoring/development activities or initiate new ones OR
+- support current mentoring/development activities or initiate new ones 
 - join the Instructor Development Committee
-	- Sign up for the Instructor Development Committee [mailing list][comm-mailing-list] and attend the next meeting (scheduled on [this etherpad](meetings)
-
-For a complete summary of different mentoring roles, see [this page](roles/README.md).
-
+	- Sign up for the Instructor Development Committee [mailing list][comm-mailing-list] and attend the next meeting (scheduled on [this etherpad](meetings).
 
 ## Training Committee Liaison
 
-* Erin Becker
+* Vacant
 
 ## Executive Council Liaison
 
-* Raniere Silva
+* Vacant
 
-## Staff Liaison
+## Staff Liaisons
 
-* Kari Jordan (@kariljordan, [@DrKariLJordan](https://twitter.com/DrKariLJordan))
+* Kari L. Jordan (@kariljordan, [@DrKariLJordan](https://twitter.com/DrKariLJordan))
+* Serah Rono (@serarono, [@SeraRono](https://twitter.com/SeraRono))
 
-## Current Members
+## Instructor Development Committee Leadership Team
+* Sarah Stevens, Co-Chair
+* Arindam Basu, Co-Chair
+* Kemi Megbowon, Secretary
+* Tobin Magle, Communications Chair
+* Marco Chiapello, Mentoring Chair
+* Martin Dreyer, Discussion Chair
+
+## Past Instructor Development Committee Members
 
 * Erin Becker
 * Jonah Duckles
@@ -73,7 +74,7 @@ For a complete summary of different mentoring roles, see [this page](roles/READM
 * Rayna Harris (@raynamharris, [@raynamharris](https://twitter.com/raynamharris))
 * Kate Hertweck (@k8hertweck, [k8hert](https://twitter.com/k8hert))
 * Toby Hodges (Co-chair, @tobyhodges, [@tbyhdgs](https://twitter.com/tbyhdgs))
-* Kari Jordan (@kariljordan, [@DrKariLJordan](https://twitter.com/DrKariLJordan))
+* Kari L. Jordan (@kariljordan, [@DrKariLJordan](https://twitter.com/DrKariLJordan))
 * Christina Koch (@ChristinaLK, [@_christinaLK](https://twitter.com/_christinaLK))
 * Mateusz Kuzak (@mkuzak, [@matkuzak](https://twitter.com/matkuzak))
 * Mark Laufersweiler
@@ -86,11 +87,6 @@ For a complete summary of different mentoring roles, see [this page](roles/READM
 * Juan Steyn
 * Tracy Teal (@tracykteal, [@tracykteal](https://twitter.com/tracykteal))
 * Belinda Weaver (@weaverbel, [@cloudaus](https://twitter.com/cloudaus))
-
-_* membership list based on attendance of ≥2 subcommittee meetings since October 2016._
-
-## Past Members
-
 * Daniel Chen (@chendaniely, [@chendaniely](https://twitter.com/chendaniely))
 * Karin Lagesen (@karinlag, [@karinlag](https://twitter.com/karinlag))
 * Sheldon McKay (@mckays630)
@@ -100,6 +96,8 @@ _* membership list based on attendance of ≥2 subcommittee meetings since Octob
 * Michael Sarahan (@msarahan)
 * Tiffany Timbers (@ttimbers, [@TiffanyTimbers](https://twitter.com/TiffanyTimbers))
 * Carol Willing (@willingc, [@WillingCarol](https://twitter.com/WillingCarol))
+
+_* membership list based on attendance of ≥2 subcommittee meetings since October 2016._
 
 [discussion]: https://pad.carpentries.org/community-discussions
 [host-mailing-list]: https://carpentries.topicbox.com/groups/discussion-hosts


### PR DESCRIPTION
Updated README to include current contact information. Added IDC Leadership Team. @arinbasu @sstevens2 We used to have liaisons from the Trainers Community and Executive Council who came to our meetings to provide updates, or at least put their updates on the Etherpad. Do we plan to do this?